### PR TITLE
Pod error fix + test

### DIFF
--- a/lib/ore/Beer.pm
+++ b/lib/ore/Beer.pm
@@ -42,19 +42,19 @@ You can also look for information at:
 
 =over 4
 
-=item *metaCPAN
+=item metaCPAN
 
 L<https://metacpan.org/module/ore-Beer/>
 
-=item * AnnoCPAN: Annotated CPAN documentation
+=item AnnoCPAN: Annotated CPAN documentation
 
 L<http://annocpan.org/dist/ore::Beer>
 
-=item * CPAN Ratings
+=item CPAN Ratings
 
 L<http://cpanratings.perl.org/d/ore::Beer>
 
-=item * Search CPAN
+=item Search CPAN
 
 L<http://search.cpan.org/dist/ore::Beer>
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,0 +1,8 @@
+#!perl -T
+
+use Test::More;
+eval 'use Test::Pod 1.00';
+
+plan skip_all => 'Test::Pod 1.00 required for all_pod_files_ok()' if $@;
+
+all_pod_files_ok();


### PR DESCRIPTION
`=item * Foobar` produces the POD error message of `Expected text after =item, not a bullet` while `=item *Foobar` (notice the space missing) does not.

I have removed the bullet points, but those could be returned to match how `*metaCPAN` appears before my proposed diff, which also avoids errors.

Regardless, I have included a POD test script.
